### PR TITLE
Fix not working validation

### DIFF
--- a/assets/snippets/eform/eform.inc.php
+++ b/assets/snippets/eform/eform.inc.php
@@ -192,8 +192,7 @@ function eForm($modx,$params) {
 		foreach($fields as $name => $value) {
             if(isset($formats[$name])){
                 $fld = $formats[$name];
-            }
-            if (isset($fld)) {
+
                 $desc		= $fld[1];
 				$datatype 	= $fld[2];
 				$isRequired = $fld[3];


### PR DESCRIPTION
Since 4fb0f1724c460f019a0500201c9247d49f49a51e the validation shows errors for hidden fields in my forms. This is caused by a not reset $fld variable in the loop, when $formats[$name] is not set. In that case the old $fld value was used with the value of the new field.